### PR TITLE
Fixed missing street in shipping address

### DIFF
--- a/Model/Adapter/QuickPayAdapter.php
+++ b/Model/Adapter/QuickPayAdapter.php
@@ -125,7 +125,7 @@ class QuickPayAdapter
             if($shippingAddress) {
                 $form['shipping_address'] = [];
                 $form['shipping_address']['name'] = $shippingAddress->getFirstName() . " " . $shippingAddress->getLastName();
-                $form['shipping_address']['street'] = $shippingAddress->getStreetLine1();
+                $form['shipping_address']['street'] = $shippingAddress->getStreetLine(1);
                 $form['shipping_address']['city'] = $shippingAddress->getCity();
                 $form['shipping_address']['zip_code'] = $shippingAddress->getPostcode();
                 $form['shipping_address']['region'] = $shippingAddress->getRegionCode();


### PR DESCRIPTION
`$shippingAddress` is instance of `Magento\Sales\Model\Order\Address` class.
You should use either `$shippingAddress->getStreet()[0]` or `$shippingAddress->getStreetLine(1)` to get shipping street.