### PR TITLE
Fallback to acquirer when saving payment details

### DIFF
--- a/Controller/Payment/CallbackM23.php
+++ b/Controller/Payment/CallbackM23.php
@@ -209,6 +209,10 @@ class Callback extends \Magento\Framework\App\Action\Action implements CsrfAware
                             $payment->setCcType($response->metadata->payment_method);
                             $payment->setAdditionalInformation('Transaction ID', $response->id);
                             $payment->setAdditionalInformation('Type', $response->metadata->payment_method);
+                        } elseif (isset($response->acquirer) && $response->acquirer) {
+                            $payment->setCcType($response->acquirer);
+                            $payment->setAdditionalInformation('Transaction ID', $response->id);
+                            $payment->setAdditionalInformation('Type', $response->acquirer);
                         }
                     }
 


### PR DESCRIPTION
When using Viabill, the payment transaction is not marked as such.
The acquirer field is where this information lies for Viabill orders and not `$response->metadata->payment_method` as one would expect.

See: 
![image](https://user-images.githubusercontent.com/7666143/92235674-5ffa8900-eeb4-11ea-93ea-a3af9914b9db.png)


This proposed change falls back to the acquirer field, so that the "cc-type" is noted as Viabill.