### PR TITLE
Fixed scope of text on statement

### DIFF
--- a/Model/Adapter/QuickPayAdapter.php
+++ b/Model/Adapter/QuickPayAdapter.php
@@ -133,7 +133,7 @@ class QuickPayAdapter
                 'currency' => $order->getOrderCurrency()->ToString(),
             ];
 
-            if ($textOnStatement = $this->scopeConfig->getValue(self::TEXT_ON_STATEMENT_XML_PATH)) {
+            if ($textOnStatement = $this->scopeConfig->getValue(self::TEXT_ON_STATEMENT_XML_PATH, \Magento\Store\Model\ScopeInterface::SCOPE_STORE)) {
                 $form['text_on_statement'] = $textOnStatement;
             }
 
@@ -290,7 +290,7 @@ class QuickPayAdapter
                 'currency' => $quote->getQuoteCurrencyCode(),
             ];
 
-            if ($textOnStatement = $this->scopeConfig->getValue(self::TEXT_ON_STATEMENT_XML_PATH)) {
+            if ($textOnStatement = $this->scopeConfig->getValue(self::TEXT_ON_STATEMENT_XML_PATH, \Magento\Store\Model\ScopeInterface::SCOPE_STORE)) {
                 $form['text_on_statement'] = $textOnStatement;
             }
 


### PR DESCRIPTION
There seems to be an issue when you set the text on statement differently in multiple store views.
This should fix the issue by getting the text on statement set in store view scope instead of default scope.