### PR TITLE
Handle empty body

### DIFF
--- a/Model/Adapter/QuickPayAdapter.php
+++ b/Model/Adapter/QuickPayAdapter.php
@@ -623,6 +623,7 @@ class QuickPayAdapter
     /**
      * @param $order
      * @param $payments
+     * @param $type
      * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function validateResponse($order, $payments, $type){


### PR DESCRIPTION
Updated the validateResponse method comment field, to include the type parameter. 

Allows some payment method to have empty response body from the api.
Currently only allows Klarna payment, but the allowedEmptyResponse can be expanded to include additional payment methods, either through Magento plugin or overwriting.
