### PR TITLE
Don't update the checkout page layout

### DIFF
--- a/view/frontend/layout/checkout_index_index.xml
+++ b/view/frontend/layout/checkout_index_index.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
         <css src="QuickPay_Gateway::css/style.css" />
     </head>


### PR DESCRIPTION
The default magento 2 `layout` argument for the `checkout_index_index` handle is `checkout`. See [here](https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Checkout/view/frontend/layout/checkout_index_index.xml#L8).

We don't want to update this. Other modules/extensions often expect the [`checkout` page layout](https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Checkout/view/frontend/page_layout/checkout.xml) to be still in use.

For example, to add content to the checkout header, the `checkout.header.container` container is used. By setting the layout to `1column` as this extension currently does, this container is no longer present on the page, leading to undesirable results.