### PR TITLE
Payment logo Horizontal

### DIFF
--- a/view/frontend/web/css/style.css
+++ b/view/frontend/web/css/style.css
@@ -1,6 +1,6 @@
 .quickpay-logo {
     height: 25px;
-    margin-left: 5px;
+    margin: 5px; /* addpacing around logo */
 }
 .mobilepay-wrapper {
     margin-bottom: 40px;
@@ -26,5 +26,4 @@
 .onestepcheckout-index-index .page-main .checkout-container img.quickpay-logo {
     display: inline-block;
     vertical-align: top;
-    margin: 5px;
 }

--- a/view/frontend/web/css/style.css
+++ b/view/frontend/web/css/style.css
@@ -1,6 +1,6 @@
 .quickpay-logo {
     height: 25px;
-    margin: 5px;
+    margin-left: 5px;
 }
 .mobilepay-wrapper {
     margin-bottom: 40px;

--- a/view/frontend/web/css/style.css
+++ b/view/frontend/web/css/style.css
@@ -1,6 +1,6 @@
 .quickpay-logo {
     height: 25px;
-    margin-left: 5px;
+    margin: 5px;
 }
 .mobilepay-wrapper {
     margin-bottom: 40px;
@@ -20,4 +20,11 @@
     transform: translateY(-50%);
     margin: auto;
     top:50%;
+}
+
+/* Module payment logo align  */
+.onestepcheckout-index-index .page-main .checkout-container img.quickpay-logo {
+    display: inline-block;
+    vertical-align: top;
+    margin: 5px;
 }


### PR DESCRIPTION
### Payment logo Horizontal
This CSS will only be applied if the QuickPay Module & Aheadworks OneStep Module are enabled together. This CSS will not affect any other modules.

**Before**:
![default-payment-option](https://user-images.githubusercontent.com/106967498/227121471-28a822f7-3055-46eb-b473-d1ff6763d4d7.png)

**After CSS Changes**:
![after-change-payment-option](https://user-images.githubusercontent.com/106967498/227121498-89cf1829-e5bb-4d64-adf8-aacfe8e3d5d3.png)