### PR TITLE
explode requires a string, incase payment TransactionId is null the p…

### DIFF
--- a/Model/Payment.php
+++ b/Model/Payment.php
@@ -105,7 +105,7 @@ class Payment extends \Magento\Payment\Model\Method\AbstractMethod
     {
         $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
         $adapter = $objectManager->get(\QuickPay\Gateway\Model\Adapter\QuickPayAdapter::class);
-        $parts = explode('-',$payment->getTransactionId());
+        $parts = $this->splitTransactionId($payment);
         $order = $payment->getOrder();
         $transaction = $parts[0];
 
@@ -132,7 +132,7 @@ class Payment extends \Magento\Payment\Model\Method\AbstractMethod
     {
         $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
         $adapter = $objectManager->get(\QuickPay\Gateway\Model\Adapter\QuickPayAdapter::class);
-        $parts = explode('-',$payment->getTransactionId());
+        $parts = $this->splitTransactionId($payment);
         $order = $payment->getOrder();
         $transaction = $parts[0];
 
@@ -157,7 +157,7 @@ class Payment extends \Magento\Payment\Model\Method\AbstractMethod
     {
         $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
         $adapter = $objectManager->get(\QuickPay\Gateway\Model\Adapter\QuickPayAdapter::class);
-        $parts = explode('-',$payment->getTransactionId());
+        $parts = $this->splitTransactionId($payment);
         $order = $payment->getOrder();
         $transaction = $parts[0];
 
@@ -170,5 +170,10 @@ class Payment extends \Magento\Payment\Model\Method\AbstractMethod
         }
 
         return $this;
+    }
+
+    public function splitTransactionId($payment)
+    {
+        return explode('-',$payment->getTransactionId() ?? '');
     }
 }


### PR DESCRIPTION
Payment should fail based on payment criteria, not php standard.

Added new method to reduce code repitition and ensured fallback to string incase `getTransactionId` returns a non string

```
[2023-05-22T04:59:18.063860+00:00] main.CRITICAL: Exception: Deprecated Functionality: explode(): Passing null to parameter #2 ($string) of type string is deprecated in {webapp}/vendor/quickpay/magento2/Model/Payment.php on line 108 in {webapp}/vendor/magento/framework/App/ErrorHandler.php:62
Stack trace:
#0 [internal function]: Magento\Framework\App\ErrorHandler->handler()
#1 {webapp}/vendor/quickpay/magento2/Model/Payment.php(108): explode()
#2 {webapp}/vendor/magento/module-sales/Model/Order/Payment/Operations/ProcessInvoiceOperation.php(83): QuickPay\Gateway\Model\Payment->capture()
#3 {webapp}/vendor/magento/module-sales/Model/Order/Payment/Operations/CaptureOperation.php(73): Magento\Sales\Model\Order\Payment\Operations\ProcessInvoiceOperation->execute()
```