### PR TITLE
Set a payment group, name group for the module

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -32,6 +32,7 @@
                 <can_void>1</can_void>
                 <can_cancel>1</can_cancel>
                 <can_refund>1</can_refund>
+                <group>quickpay</group>
                 <apikey backend_model="Magento\Config\Model\Config\Backend\Encrypted" />
                 <private_key backend_model="Magento\Config\Model\Config\Backend\Encrypted" />
                 <mobilepay>
@@ -61,6 +62,7 @@
                 <can_void>1</can_void>
                 <can_cancel>1</can_cancel>
                 <can_refund>1</can_refund>
+                <group>quickpay</group>
             </quickpay_klarna>
             <quickpay_mobilepay>
                 <model>QuickPay\Gateway\Model\MobilePay</model>
@@ -79,6 +81,7 @@
                 <can_void>1</can_void>
                 <can_cancel>1</can_cancel>
                 <can_refund>1</can_refund>
+                <group>quickpay</group>
             </quickpay_mobilepay>
             <quickpay_vipps>
                 <model>QuickPay\Gateway\Model\Vipps</model>
@@ -96,6 +99,7 @@
                 <can_void>1</can_void>
                 <can_cancel>1</can_cancel>
                 <can_refund>1</can_refund>
+                <group>quickpay</group>
             </quickpay_vipps>
             <quickpay_paypal>
                 <model>QuickPay\Gateway\Model\PayPal</model>
@@ -113,6 +117,7 @@
                 <can_void>1</can_void>
                 <can_cancel>1</can_cancel>
                 <can_refund>1</can_refund>
+                <group>quickpay</group>
             </quickpay_paypal>
             <quickpay_viabill>
                 <model>QuickPay\Gateway\Model\ViaBill</model>
@@ -130,6 +135,7 @@
                 <can_void>1</can_void>
                 <can_cancel>1</can_cancel>
                 <can_refund>1</can_refund>
+                <group>quickpay</group>
             </quickpay_viabill>
             <quickpay_swish>
                 <model>QuickPay\Gateway\Model\Swish</model>
@@ -147,6 +153,7 @@
                 <can_void>1</can_void>
                 <can_cancel>1</can_cancel>
                 <can_refund>1</can_refund>
+                <group>quickpay</group>
             </quickpay_swish>
             <quickpay_trustly>
                 <model>QuickPay\Gateway\Model\Trustly</model>
@@ -165,6 +172,7 @@
                 <can_void>1</can_void>
                 <can_cancel>1</can_cancel>
                 <can_refund>1</can_refund>
+                <group>quickpay</group>
             </quickpay_trustly>
             <quickpay_anyday>
                 <model>QuickPay\Gateway\Model\Anyday</model>
@@ -182,6 +190,7 @@
                 <can_void>1</can_void>
                 <can_cancel>1</can_cancel>
                 <can_refund>1</can_refund>
+                <group>quickpay</group>
             </quickpay_anyday>
             <quickpay_applepay>
                 <model>QuickPay\Gateway\Model\ApplePay</model>
@@ -200,6 +209,7 @@
                 <can_void>1</can_void>
                 <can_cancel>1</can_cancel>
                 <can_refund>1</can_refund>
+                <group>quickpay</group>
             </quickpay_applepay>
             <quickpay_googlepay>
                 <model>QuickPay\Gateway\Model\GooglePay</model>
@@ -218,6 +228,7 @@
                 <can_void>1</can_void>
                 <can_cancel>1</can_cancel>
                 <can_refund>1</can_refund>
+                <group>quickpay</group>
             </quickpay_googlepay>
         </payment>
         <carriers>

--- a/etc/payment.xml
+++ b/etc/payment.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<payment xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Payment:etc/payment.xsd">
+    <groups>
+        <group id="quickpay">
+            <label>Quickpay Paypal</label>
+        </group>
+    </groups>
+</payment>


### PR DESCRIPTION
Hello, I am a developer from Bss Company. I would like to provide some suggestions regarding your QuickPay_Gateway module. Upon reviewing this, specifically the QuickPay Payment, QuickPay MobilePay, and other QuickPay payment methods, I noticed that they do not have a payment group and the group name is missing. The absence of these items prevents our module, Bss_AutoInvoice, from grouping these payments together and runs its functionality, as demonstrated in this image: https://imgur.com/O1uNqLs. This issue may also affect other similar modules that have auto invoice and shipment features.

I believe that addressing this issue by updating the module would be beneficial for both our company and our customers. Therefore, I kindly request your consideration and approval for our suggested changes. Please let us know if you find this proposal acceptable.

Thank you for your attention to this matter, and I look forward to hearing from you.